### PR TITLE
Fixes "Module Ads Search requires at least one additional module to be e...

### DIFF
--- a/ads_search/ads_search.install
+++ b/ads_search/ads_search.install
@@ -28,6 +28,17 @@ function ads_search_requirements($phase) {
         $requirements['ads_search']['value'] = $t('OK');
       }
     }
+    elseif (!empty($_POST['form_build_id'])) {
+      // Features form saved (after dependendies confirmation).
+      $form_state = array();
+      form_get_cache($_POST['form_build_id'], $form_state);
+      $additional_modules = &$form_state['storage']['more_required'];
+
+      if (array_key_exists('ads_search_db', $additional_modules) || array_key_exists('ads_search_solr', $additional_modules)) {
+        // One of the modules has been marked to be enabled.
+        $requirements['ads_search']['value'] = $t('OK');
+      }
+    }
     elseif (drupal_is_cli() && function_exists('drush_main')) {
       // Is it a Drush "pm-enable"?
       $context   = drush_get_context();


### PR DESCRIPTION
...nabled: Ads Search via DB or Ads Search Solr." when enabling "ads_search_db" or "ads_search_solr" modules first time without enabling "ads_search" module

refs https://github.com/mycognitive/ads/issues/12
